### PR TITLE
PD as an option - Bind to RGC

### DIFF
--- a/vmapper.sh
+++ b/vmapper.sh
@@ -50,12 +50,14 @@ fi
 get_server(){
 if [ "$vmserver" ]
 then
-      server_url=$vmserver
+    server_url=$vmserver
+    echo "`date +%Y-%m-%d_%T` Using vm server address" >> $logfile
 elif [ "$pserver" ]
 then 
-	server_url=$pserver
+    server_url=$pserver
+    echo "`date +%Y-%m-%d_%T` No vm server address found, using pd" >> $logfile
 else
-      echo "`date +%Y-%m-%d_%T` No server adress found on VMapper or Pogodroid" >> $logfile
+    echo "`date +%Y-%m-%d_%T` No server address found for VMapper or Pogodroid" >> $logfile
 fi
 }
 

--- a/vmapper.sh
+++ b/vmapper.sh
@@ -351,9 +351,9 @@ pd_to_vm(){
 vmconf="/data/data/de.goldjpg.vmapper/shared_prefs/config.xml"
 vmuser=$(ls -la /data/data/de.goldjpg.vmapper/|head -n2|tail -n1|awk '{print $3}')
 # disable pd daemon
-sed -i 's,\"full_daemon\" value=\"true\",\"full_daemon\" value=\"false\",g' $rgcconf
-chmod 660 $rgcconf
-chown $puser:$puser $rgcconf
+sed -i 's,\"full_daemon\" value=\"true\",\"full_daemon\" value=\"false\",g' $pdconf
+chmod 660 $pdconf
+chown $puser:$puser $pdconf
 
 # enable vm daemon
 sed -i 's,\"daemon\" value=\"false\",\"daemon\" value=\"true\",g' $vmconf

--- a/vmapper.sh
+++ b/vmapper.sh
@@ -98,8 +98,9 @@ am force-stop com.nianticlabs.pokemongo
 echo "`date +%Y-%m-%d_%T` VM install: pogodroid disabled" >> $logfile
 
 ## Install vmapper
+get_server
 /system/bin/rm -f /sdcard/Download/vmapper.apk
-/system/bin/curl -k -s -L -o /sdcard/Download/vmapper.apk $(get_rgc_user) -H "origin: $origin" "$pserver/mad_apk/vm/download"
+/system/bin/curl -k -s -L -o /sdcard/Download/vmapper.apk $(get_rgc_user) -H "origin: $origin" "$server_url/mad_apk/vm/download"
 /system/bin/pm install -r /sdcard/Download/vmapper.apk
 /system/bin/rm -f /sdcard/Download/vmapper.apk
 echo "`date +%Y-%m-%d_%T` VM install: vmapper installed" >> $logfile
@@ -137,8 +138,9 @@ reboot=1
 
 vmapper_wizard(){
 #check update vmapper and download from wizard
+get_server
 checkrgcconf || return 1
-! [[ "$pserver" ]] && echo "`date +%Y-%m-%d_%T` RemoteGpsController endpoint not configured yet, cannot contact the wizard" >> $logfile && return 1
+! [[ "$server_url" ]] && echo "`date +%Y-%m-%d_%T` VMapper or PD endpoint not configured yet, cannot contact the wizard" >> $logfile && return 1
 
 newver="$(/system/bin/curl -s -k -L $(get_rgc_user) -H "origin: $origin" "$pserver/mad_apk/vm/noarch" | awk '{print substr($1,2); }')"
 installedver="$(dumpsys package de.goldjpg.vmapper|awk -F'=' '/versionName/{print $2}'|head -n1 | awk '{print substr($1,2); }')"
@@ -146,7 +148,7 @@ installedver="$(dumpsys package de.goldjpg.vmapper|awk -F'=' '/versionName/{prin
 if checkupdate "$newver" "$installedver" ;then
  echo "`date +%Y-%m-%d_%T` New vmapper version detected in wizard, updating $installedver=>$newver" >> $logfile
  /system/bin/rm -f /sdcard/Download/vmapper.apk
- until /system/bin/curl -k -s -L -o /sdcard/Download/vmapper.apk $(get_rgc_user) -H "origin: $origin" "$pserver/mad_apk/vm/download" ;do
+ until /system/bin/curl -k -s -L -o /sdcard/Download/vmapper.apk $(get_rgc_user) -H "origin: $origin" "$server_url/mad_apk/vm/download" ;do
   /system/bin/rm -f /sdcard/Download/vmapper.apk
   sleep
  done
@@ -186,7 +188,7 @@ installedver="$(dumpsys package com.nianticlabs.pokemongo|awk -F'=' '/versionNam
 if checkupdate "$newver" "$installedver" ;then
  echo "`date +%Y-%m-%d_%T` New pogo version detected in wizard, updating $installedver=>$newver" >> $logfile
  /system/bin/rm -f /sdcard/Download/pogo.apk
- until /system/bin/curl -k -s -L -o /sdcard/Download/pogo.apk $(get_rgc_user) -H "origin: $origin" "$pserver/mad_apk/pogo/$arch/download" ;do
+ until /system/bin/curl -k -s -L -o /sdcard/Download/pogo.apk $(get_rgc_user) -H "origin: $origin" "$get_server/mad_apk/pogo/$arch/download" ;do
   /system/bin/rm -f /sdcard/Download/pogo.apk
   sleep
  done
@@ -215,16 +217,17 @@ fi
 
 rgc_wizard(){
 #check update rgc and download from wizard
+get_server
 checkrgcconf || return 1
-! [[ "$pserver" ]] && echo "RemoteGpsController endpoint not configured yet, cannot contact the wizard" && return 1
+! [[ "$get_server" ]] && echo "RemoteGpsController endpoint not configured yet, cannot contact the wizard" && return 1
 
-newver="$(curl -s -k -L $(get_rgc_user) -H "origin: $origin" "$pserver/mad_apk/rgc/noarch")"
+newver="$(curl -s -k -L $(get_rgc_user) -H "origin: $origin" "$server_url/mad_apk/rgc/noarch")"
 installedver="$(dumpsys package de.grennith.rgc.remotegpscontroller 2>/dev/null|awk -F'=' '/versionName/{print $2}'|head -n1)"
 
 if checkupdate "$newver" "$installedver" ;then
  echo "`date +%Y-%m-%d_%T` New rgc version detected in wizard, updating $installedver=>$newver" >> $logfile
  rm -f /sdcard/Download/RemoteGpsController.apk
- until curl -o /sdcard/Download/RemoteGpsController.apk  -s -k -L $(get_rgc_user) -H "origin: $origin" "$pserver/mad_apk/rgc/download" ;do
+ until curl -o /sdcard/Download/RemoteGpsController.apk  -s -k -L $(get_rgc_user) -H "origin: $origin" "$server_url/mad_apk/rgc/download" ;do
   rm -f /sdcard/Download/RemoteGpsController.apk
   sleep 2
  done
@@ -335,10 +338,10 @@ fi
 
 
 vmapper_xml(){
-vmconf="/data/data/de.goldjpg.vmapper/shared_prefs/config.xml"
+get_server
 vmuser=$(ls -la /data/data/de.goldjpg.vmapper/|head -n2|tail -n1|awk '{print $3}')
 
-/system/bin/curl -k -s -L -o $vmconf $(get_rgc_user) -H "origin: $origin" "$pserver/vm_conf"
+/system/bin/curl -k -s -L -o $vmconf $(get_rgc_user) -H "origin: $origin" "$server_url/vm_conf"
 
 chmod 660 $vmconf
 chown $vmuser:$vmuser $vmconf

--- a/vmapper.sh
+++ b/vmapper.sh
@@ -12,12 +12,15 @@ rm -f /sdcard/vmapper_conf
 logfile="/sdcard/vm.log"
 pdconf="/data/data/com.mad.pogodroid/shared_prefs/com.mad.pogodroid_preferences.xml"
 rgcconf="/data/data/de.grennith.rgc.remotegpscontroller/shared_prefs/de.grennith.rgc.remotegpscontroller_preferences.xml"
+vmconf="/data/data/de.goldjpg.vmapper/shared_prefs/config.xml"
 puser=$(ls -la /data/data/com.mad.pogodroid/|head -n2|tail -n1|awk '{print $3}')
 authpassword=$(grep 'auth_password' $rgcconf | sed -e 's/    <string name="auth_password">\(.*\)<\/string>/\1/')
 authuser=$(grep 'auth_username' $rgcconf | sed -e 's/    <string name="auth_username">\(.*\)<\/string>/\1/')
 origin=$(grep 'post_origin' $rgcconf | sed -e 's/    <string name="post_origin">\(.*\)<\/string>/\1/')
 postdest=$(grep -w 'post_destination' $rgcconf | sed -e 's/    <string name="post_destination">\(.*\)<\/string>/\1/')
 pserver=$(grep -v raw "$rgcconf"|awk -F'>' '/post_destination/{print $2}'|awk -F'<' '{print $1}')
+rgcserver=$(grep -v raw "$rgcconf"|awk -F'>' '/post_destination/{print $2}'|awk -F'<' '{print $1}')
+vmserver=$(grep -v raw "$rgcconf"|awk -F'>' '/postdest/{print $2}'|awk -F'<' '{print $1}')
 
 
 reboot_device(){
@@ -41,6 +44,18 @@ user=$(awk -F'>' '/auth_username/{print $2}' "$rgcconf"|awk -F'<' '{print $1}')
 pass=$(awk -F'>' '/auth_password/{print $2}' "$rgcconf"|awk -F'<' '{print $1}')
 if [[ "$user" ]] ;then
  printf "-u $user:$pass"
+fi
+}
+
+get_server(){
+if [ "$vmserver" ]
+then
+      server_url=$vmserver
+elif [ "$pserver" ]
+then 
+	server_url=$pserver
+else
+      echo "`date +%Y-%m-%d_%T` No server adress found on VMapper or Pogodroid" >> $logfile
 fi
 }
 
@@ -372,7 +387,7 @@ reboot=1
 
 
 vm_to_pd(){
-vmconf="/data/data/de.goldjpg.vmapper/shared_prefs/config.xml"
+
 vmuser=$(ls -la /data/data/de.goldjpg.vmapper/|head -n2|tail -n1|awk '{print $3}')
 # disable vm daemon
 sed -i 's,\"daemon\" value=\"true\",\"daemon\" value=\"false\",g' $vmconf


### PR DESCRIPTION
PD is optional software for vmappers and it may contain outdated settings later on. Since PD is not used, scripts should not get info from it as default.
Binding to RGC on all options except the ones regarding PD to Vmapper (and reversal) conversion.

(Still untested)