### PR TITLE
Develop

### DIFF
--- a/vmapper.sh
+++ b/vmapper.sh
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-# version 2.47
+# version 2.48
 
 #Create logfile
 if [ ! -e /sdcard/vm.log ] ;then
@@ -272,6 +272,11 @@ if [ -z ${force_pogo_update+x} ]; then
 else
   newver="1.599.1"
 fi
+
+if [[ $newver == "Supported version not installed" ]] ;then
+newver="1.599.1"
+fi
+
 installedver="$(dumpsys package com.nianticlabs.pokemongo|awk -F'=' '/versionName/{print $2}')"
 
 if checkupdate "$newver" "$installedver" ;then

--- a/vmapper.sh
+++ b/vmapper.sh
@@ -258,7 +258,7 @@ else
       /system/bin/rm -f /sdcard/Download/vmapper.apk
       until /system/bin/curl -k -s -L --fail --show-error -o /sdcard/Download/vmapper.apk -u $authuser:$authpassword -H "origin: $origin" "$server/mad_apk/vm/download" ;do
        /system/bin/rm -f /sdcard/Download/vmapper.apk
-       sleep
+       sleep 2
       done
 
       # set vmapper to be installed

--- a/vmapper.sh
+++ b/vmapper.sh
@@ -620,7 +620,7 @@ sed -i 's,\"autostart_services\" value=\"false\",\"autostart_services\" value=\"
 sed -i 's,\"boot_startup\" value=\"false\",\"boot_startup\" value=\"true\",g' $rgcconf
 chmod 660 $rgcconf
 chown $ruser:$ruser $rgcconf
-# disable rgc autoupdate
+# enable rgc autoupdate
 rm -f /sdcard/disableautorgcupdate
 
 # restart vm & start rgc

--- a/vmapper.sh
+++ b/vmapper.sh
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-# version 2.51
+# version 2.52
 
 #Create logfile
 if [ ! -e /sdcard/vm.log ] ;then
@@ -59,6 +59,7 @@ elif [ -f "$lastResort" ]; then
   echo "`date +%Y-%m-%d_%T` Using settings stored in /sdcard/vm_last_resort"  >> $logfile
 else
   echo "`date +%Y-%m-%d_%T` No settings found to connect to MADmin, exiting vmapper.sh" >> $logfile
+  echo "No settings found to connect to MADmin, exiting vmapper.sh"
   exit 1
 fi
 

--- a/vmapper.sh
+++ b/vmapper.sh
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-# version 2.53
+# version 2.54
 
 #Create logfile
 if [ ! -e /sdcard/vm.log ] ;then
@@ -188,6 +188,8 @@ am force-stop com.mad.pogodroid
 # let us kill pogo as well
 am force-stop com.nianticlabs.pokemongo
 echo "`date +%Y-%m-%d_%T` VM install: pogodroid disabled" >> $logfile
+# disable pd autoupdate
+touch /sdcard/disableautopogodroidupdate
 
 ## Install vmapper
 /system/bin/rm -f /sdcard/Download/vmapper.apk
@@ -532,6 +534,8 @@ vmuser=$(ls -la /data/data/de.vahrmap.vmapper/|head -n2|tail -n1|awk '{print $3}
 sed -i 's,\"full_daemon\" value=\"true\",\"full_daemon\" value=\"false\",g' $pdconf
 chmod 660 $pdconf
 chown $puser:$puser $pdconf
+# disable pd autoupdate
+touch /sdcard/disableautopogodroidupdate
 
 # enable vm daemon
 sed -i 's,\"daemon\" value=\"false\",\"daemon\" value=\"true\",g' $vmconf
@@ -561,6 +565,8 @@ chown $vmuser:$vmuser $vmconf
 sed -i 's,\"full_daemon\" value=\"false\",\"full_daemon\" value=\"true\",g' $pdconf
 chmod 660 $pdconf
 chown $puser:$puser $pdconf
+# enable pd autoupdate
+rm -f /sdcard/disableautopogodroidupdate
 
 #kill vm & start pd
 am force-stop de.vahrmap.vmapper
@@ -583,6 +589,8 @@ sed -i 's,\"autostart_services\" value=\"true\",\"autostart_services\" value=\"f
 sed -i 's,\"boot_startup\" value=\"true\",\"boot_startup\" value=\"false\",g' $rgcconf
 chmod 660 $rgcconf
 chown $ruser:$ruser $rgcconf
+# disable rgc autoupdate
+touch /sdcard/disableautorgcupdate
 
 # enable vm mockgps
 sed -i 's,\"mockgps\" value=\"false\",\"mockgps\" value=\"true\",g' $vmconf
@@ -612,6 +620,8 @@ sed -i 's,\"autostart_services\" value=\"false\",\"autostart_services\" value=\"
 sed -i 's,\"boot_startup\" value=\"false\",\"boot_startup\" value=\"true\",g' $rgcconf
 chmod 660 $rgcconf
 chown $ruser:$ruser $rgcconf
+# disable rgc autoupdate
+rm -f /sdcard/disableautorgcupdate
 
 # restart vm & start rgc
 am broadcast -n de.vahrmap.vmapper/.RestartService

--- a/vmapper.sh
+++ b/vmapper.sh
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-# version 2.48
+# version 2.49
 
 #Create logfile
 if [ ! -e /sdcard/vm.log ] ;then
@@ -132,6 +132,14 @@ sed -i 's,\"mockgps\" value=\"false\",\"mockgps\" value=\"true\",g' $vmconfV7
 am broadcast -n de.vahrmap.vmapper/.RestartService
 echo "`date +%Y-%m-%d_%T` VMconf check: rgc deactivated and vmapper mockgps disabled, enabled mockgps and restarted vmapper" >> $logfile
 fi
+
+# ensure vmapper mockgps is active for useApi
+if [ -f "$vmconfV7" ] && [[ $(grep -w 'useApi' $vmconfV7 | awk -F "\"" '{print $4}') == "true" ]] && [[ $(grep -w 'mockgps' $vmconfV7 | awk -F "\"" '{print $4}') == "false" ]] ;then
+sed -i 's,\"mockgps\" value=\"false\",\"mockgps\" value=\"true\",g' $vmconfV7
+am broadcast -n de.vahrmap.vmapper/.RestartService
+echo "`date +%Y-%m-%d_%T` VMconf check: vmapper useApi activated and vmapper mockgps disabled, enabled mockgps and restarted vmapper" >> $logfile
+fi
+
 
 reboot_device(){
 echo "`date +%Y-%m-%d_%T` Reboot device" >> $logfile

--- a/vmapper.sh
+++ b/vmapper.sh
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-# version 2.52
+# version 2.53
 
 #Create logfile
 if [ ! -e /sdcard/vm.log ] ;then
@@ -25,11 +25,13 @@ exec 2>> $logfile
 echo "" >> $logfile
 echo "`date +%Y-%m-%d_%T` ## Executing vmapper.sh $@" >> $logfile
 
-# prevent vmconf causing reboot loop
-if [ $(cat /sdcard/vm.log | grep `date +%Y-%m-%d` | grep rebooted | wc -l) -gt 20 ] ;then
-echo "`date +%Y-%m-%d_%T` Device rebooted over 20 times today, vmapper.sh signing out, see you tomorrow"  >> $logfile
-echo "Device rebooted over 20 times today, vmapper.sh signing out, see you tomorrow.....or (re)move /sdcard/vm.log"
-exit 1
+# prevent vmconf causing reboot loop. Bypass check by executing, vmapper.sh -nrc -whatever
+if [ $1 != "-nrc" ] ;then
+  if [ $(cat /sdcard/vm.log | grep `date +%Y-%m-%d` | grep rebooted | wc -l) -gt 20 ] ;then
+  echo "`date +%Y-%m-%d_%T` Device rebooted over 20 times today, vmapper.sh signing out, see you tomorrow"  >> $logfile
+  echo "Device rebooted over 20 times today, vmapper.sh signing out, see you tomorrow.....or (re)move /sdcard/vm.log"
+  exit 1
+  fi
 fi
 
 # Get MADmin credentials and origin

--- a/vmapper.sh
+++ b/vmapper.sh
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-# version 2.50
+# version 2.51
 
 #Create logfile
 if [ ! -e /sdcard/vm.log ] ;then
@@ -28,6 +28,7 @@ echo "`date +%Y-%m-%d_%T` ## Executing vmapper.sh $@" >> $logfile
 # prevent vmconf causing reboot loop
 if [ $(cat /sdcard/vm.log | grep `date +%Y-%m-%d` | grep rebooted | wc -l) -gt 20 ] ;then
 echo "`date +%Y-%m-%d_%T` Device rebooted over 20 times today, vmapper.sh signing out, see you tomorrow"  >> $logfile
+echo "Device rebooted over 20 times today, vmapper.sh signing out, see you tomorrow.....or (re)move /sdcard/vm.log"
 exit 1
 fi
 

--- a/vmapper.sh
+++ b/vmapper.sh
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-# version 2.48
+# version 2.47
 
 #Create logfile
 if [ ! -e /sdcard/vm.log ] ;then
@@ -272,11 +272,6 @@ if [ -z ${force_pogo_update+x} ]; then
 else
   newver="1.599.1"
 fi
-
-if [[ $newver == "Supported version not installed" ]] ;then
-newver="1.599.1"
-fi
-
 installedver="$(dumpsys package com.nianticlabs.pokemongo|awk -F'=' '/versionName/{print $2}')"
 
 if checkupdate "$newver" "$installedver" ;then

--- a/vmapper.sh
+++ b/vmapper.sh
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-# version 2.49
+# version 2.50
 
 #Create logfile
 if [ ! -e /sdcard/vm.log ] ;then
@@ -216,6 +216,11 @@ mount -o remount,rw /system
 chmod +x /system/etc/init.d/55vmapper
 mount -o remount,ro /system
 echo "`date +%Y-%m-%d_%T` VM install: 55vmapper added" >> $logfile
+
+## check vmapper mockgps active
+if [ -f "$vmconfV7" ] && [[ $(grep -w 'mockgps' $vmconfV7 | awk -F "\"" '{print $4}') == "true" ]] ;then
+rgc_to_vm
+fi
 
 ## Set for reboot device
 reboot=1


### PR DESCRIPTION
3 new options, prepping for v8:
`-srv`, Switch Rgc to Vmapper. Disabling RGC making use of vmapper mock gps.
`-svr`, Switch Vmapper to Rgc. Disabling VMapper mock gps and enable RGC.
`-nrc`, bypass vmconf reboot check which disables use of vmconf on devices that have rebooted over 20 times that day. Must be 1st parameter to be passed.

